### PR TITLE
Make start app server optional

### DIFF
--- a/bin/start-nginx
+++ b/bin/start-nginx
@@ -28,28 +28,31 @@ echo 'buildpack=nginx at=logs-initialized'
 	echo 'logs' >$psmgr
 ) &
 
-#Start App Server
-(
-	#Take the command passed to this bin and start it.
-	#E.g. bin/start-nginx bundle exec unicorn -c config/unicorn.rb
-        COMMAND=${@:$n}
-	echo "buildpack=nginx at=start-app cmd=$COMMAND"
-	$COMMAND
-	echo 'app' >$psmgr
-) &
-
-if [[ -z "$FORCE" ]]
+if [ "$#" -gt "0" ]
 then
-	FILE="/tmp/app-initialized"
+	#Start App Server
+	(
+		#Take the command passed to this bin and start it.
+		#E.g. bin/start-nginx bundle exec unicorn -c config/unicorn.rb
+					COMMAND=${@:$n}
+		echo "buildpack=nginx at=start-app cmd=$COMMAND"
+		$COMMAND
+		echo 'app' >$psmgr
+	) &
 
-	#We block on app-initialized so that when NGINX binds to $PORT
-	#are app is ready for traffic.
-	while [[ ! -f "$FILE" ]]
-	do
-		echo 'buildpack=nginx at=app-initialization'
-		sleep 1
-	done
-	echo 'buildpack=nginx at=app-initialized'
+	if [[ -z "$FORCE" ]]
+	then
+		FILE="/tmp/app-initialized"
+
+		#We block on app-initialized so that when NGINX binds to $PORT
+		#are app is ready for traffic.
+		while [[ ! -f "$FILE" ]]
+		do
+			echo 'buildpack=nginx at=app-initialization'
+			sleep 1
+		done
+		echo 'buildpack=nginx at=app-initialized'
+	fi
 fi
 
 #Start NGINX


### PR DESCRIPTION
When using Nginx only as a load balancer or to serve static files, there is no need to start the app server.

So skip start app server and app process check when there is no cmd passed for `bin/start-nginx`
