### PR TITLE
Remove docker-machine instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -74,8 +74,6 @@ See [scripts/build_nginx](scripts/build_nginx) for the build steps. Configuring 
 You can run the builds in a [Docker](https://www.docker.com/) container:
 
 ```
-$ docker-machine create --driver virtualbox cedar
-$ eval "$(docker-machine env ceder)"
 $ make build # It outputs the latest builds to bin/cedar-*
 ```
 


### PR DESCRIPTION
Correct me if I'm wrong, but it seems no longer necessary.