### PR TITLE
remove unneeded Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: scripts/build_nginx.sh


### PR DESCRIPTION
We used the Procfile to build nginx on Heroku, this is not needed anymore since we use Docker to build locally