### PR TITLE
Add ngx_http_gunzip_module

### DIFF
--- a/scripts/build_nginx
+++ b/scripts/build_nginx
@@ -48,6 +48,7 @@ echo "Downloading $zlib_url"
     --with-http_gzip_static_module \
     --with-http_realip_module \
     --with-http_ssl_module \
+    --with-http_gunzip_module \
     --prefix=/tmp/nginx \
     --add-module=${temp_dir}/nginx-${NGINX_VERSION}/headers-more-nginx-module-${HEADERS_MORE_VERSION}
   make install


### PR DESCRIPTION
As a user 
When my client doesn't support gzip
And I work with heroku nginx app
I want my content to be decompressed by nginx

[https://nginx.org/en/docs/http/ngx_http_gunzip_module.html](https://nginx.org/en/docs/http/ngx_http_gunzip_module.html)