### PR TITLE
Allow for custom log paths

### DIFF
--- a/config/nginx-solo-sample.conf.erb
+++ b/config/nginx-solo-sample.conf.erb
@@ -16,8 +16,9 @@ http {
   server_tokens off;
 
   log_format l2met 'measure#nginx.service=$request_time request_id=$http_x_request_id';
-  access_log logs/nginx/access.log l2met;
-  error_log logs/nginx/error.log;
+  access_log <%= ENV['NGINX_ACCESS_LOG_PATH'] || 'logs/nginx/access.log' %> l2met;
+  error_log <%= ENV['NGINX_ERROR_LOG_PATH'] || 'logs/nginx/error.log' %>;
+
 
   include mime.types;
   default_type application/octet-stream;

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -16,8 +16,8 @@ http {
 	server_tokens off;
 
 	log_format l2met 'measure#nginx.service=$request_time request_id=$http_x_request_id';
-	access_log logs/nginx/access.log l2met;
-	error_log logs/nginx/error.log;
+	access_log <%= ENV['NGINX_ACCESS_LOG_PATH'] || 'logs/nginx/access.log' %> l2met;
+	error_log <%= ENV['NGINX_ERROR_LOG_PATH'] || 'logs/nginx/error.log' %>;
 
 	include mime.types;
 	default_type application/octet-stream;

--- a/readme.md
+++ b/readme.md
@@ -44,6 +44,14 @@ You can correlate this id with your Heroku router logs:
 ```
 at=info method=GET path=/ host=salty-earth-7125.herokuapp.com request_id=e2c79e86b3260b9c703756ec93f8a66d fwd="67.180.77.184" dyno=web.1 connect=1ms service=8ms status=200 bytes=21
 ```
+#### Setting custom log paths
+
+You can configure custom log paths using the environment variables `NGINX_ACCESS_LOG_PATH` and `NGINX_ERROR_LOG_PATH`.
+
+For example, if you wanted to stop nginx from logging your access logs you could set `NGINX_ACCESS_LOG_PATH` to `/dev/null`:
+```bash
+$ heroku config:set NGINX_ACCESS_LOG_PATH="/dev/null"
+```
 
 ### Language/App Server Agnostic
 


### PR DESCRIPTION
Since it is common to outsource application logs to a service like Papertrail in heroku, it would be nice to be able to have the option to disable nginx logging so as to not have duplicate redundant logs show up in a third party log service. Right now it is not ideal to have to keep a copy of the config file in a projects root directory incase this default configuration is updated. I think allowing for environment variables to set log paths is a flexible solutions.