### PR TITLE
Add NGINX_WORKER_CONNECTIONS env var to set worker_connections

### DIFF
--- a/config/nginx-solo-sample.conf.erb
+++ b/config/nginx-solo-sample.conf.erb
@@ -5,7 +5,7 @@ worker_processes <%= ENV['NGINX_WORKERS'] || 4 %>;
 events {
   use epoll;
   accept_mutex on;
-  worker_connections 1024;
+  worker_connections <%= ENV['NGINX_WORKER_CONNECTIONS'] || 1024 %>;
 }
 
 http {

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -5,7 +5,7 @@ worker_processes <%= ENV['NGINX_WORKERS'] || 4 %>;
 events {
 	use epoll;
 	accept_mutex on;
-	worker_connections 1024;
+	worker_connections <%= ENV['NGINX_WORKER_CONNECTIONS'] || 1024 %>;
 }
 
 http {

--- a/readme.md
+++ b/readme.md
@@ -67,7 +67,7 @@ $ cat Procfile
 web: bin/start-nginx-solo
 ```
 
-### Setting the Worker Processes
+### Setting the Worker Processes and Connections
 
 You can configure NGINX's `worker_processes` directive via the
 `NGINX_WORKERS` environment variable.
@@ -76,6 +76,12 @@ For example, to set your `NGINX_WORKERS` to 8 on a PX dyno:
 
 ```bash
 $ heroku config:set NGINX_WORKERS=8
+```
+
+Similarly, the `NGINX_WORKER_CONNECTIONS` environment variable can configure the `worker_connections` directive:
+
+```bash
+$ heroku config:set NGINX_WORKER_CONNECTIONS=2048
 ```
 
 ### Customizable NGINX Config


### PR DESCRIPTION
Useful to increase the number of connections per worker without adding more processes or using a custom conf file.