### PR TITLE
Allow for custom mime.types file in project config folder

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -13,8 +13,12 @@ echo '-----> nginx-buildpack: Added start-nginx-solo to app/bin'
 
 mkdir -p "$1/config"
 
-cp config/mime.types "$1/config/"
-echo '-----> nginx-buildpack: Default mime.types copied to app/config/'
+if [[ ! -f $1/config/mime.types ]]; then
+	cp config/mime.types "$1/config/"
+	echo '-----> nginx-buildpack: Default mime.types copied to app/config/'
+else
+	echo '-----> nginx-buildpack: Custom mime.types found in app/config.'
+fi
 
 if [[ ! -f $1/config/nginx.conf.erb ]]; then
 	cp config/nginx.conf.erb "$1/config/"


### PR DESCRIPTION
Currently, if my project includes a file `config/mime.types` adjacent to `config/nginx.conf.erb`, the buildpack will overwrite it (see [lines 16 and 17 in `bin/compile`](https://github.com/heroku/heroku-buildpack-nginx/blob/master/bin/compile#L16-L17)).

This pull request adds a check for an existing `config/mime.types` file and, if present, leaves it in place. The behavior is exactly the same as the succeeding compile step for the `config/nginx.conf.erb` file.

Thanks for taking a look!