### PR TITLE
Use application/javascript instead of application/x-javascript

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased] - 2020-06-13
+
+### Changed
+- [all] use `application/javascript` instead of `application/x-javascript` as JavaScript media type.
+
 ## [1.4] - 2020-05-05
 ### Added
 - [all] add nginx-debug binary

--- a/config/mime.types
+++ b/config/mime.types
@@ -6,7 +6,7 @@ types {
     text/cache-manifest                   manifest appcache;
     image/gif                             gif;
     image/jpeg                            jpeg jpg;
-    application/x-javascript              js;
+    application/javascript                js;
     application/atom+xml                  atom;
     application/rss+xml                   rss;
 


### PR DESCRIPTION
JavaScript media type is defined as `application/javascript` in [RFC4329](https://tools.ietf.org/html/rfc4329).

We can also use custom `mime.types` (#37), but I'd like to make the defaults better.