### PR TITLE
fix: sigterm handling so NGINX gracefully exist

### DIFF
--- a/scripts/build_nginx
+++ b/scripts/build_nginx
@@ -36,6 +36,26 @@ echo "Downloading $zlib_url"
 echo "Downloading $uuid4_url"
 (cd nginx-${NGINX_VERSION} && curl -L $uuid4_url | tar xvz )
 
+if [ -d "/buildpack/support/patchfiles/${NGINX_VERSION}" ]
+then
+    PATCHFILES=$(find /buildpack/support/patchfiles/${NGINX_VERSION} -name '*.patch')
+else
+    exit 1
+fi
+
+
+NGX_SHUTDOWN_SIGNAL=TERM
+NGX_TERMINATE_SIGNAL=QUIT
+
+(
+  cd nginx-${NGINX_VERSION}
+  for f in $PATCHFILES
+  do
+    echo "patch: $f"
+    patch -p0 < $f
+  done
+)
+
 # This will build `nginx`
 (
   cd nginx-${NGINX_VERSION}

--- a/support/patchfiles/1.18.0/001-Custom-Terminate-Signal.patch
+++ b/support/patchfiles/1.18.0/001-Custom-Terminate-Signal.patch
@@ -1,0 +1,13 @@
+--- src/core/ngx_config.h	2020-05-23 04:21:07.000000000 +0000
++++ src/core/ngx_config.h	2020-05-23 04:15:17.000000000 +0000
+@@ -56,9 +56,8 @@
+
+ #define ngx_random               random
+
+-/* TODO: #ifndef */
+-#define NGX_SHUTDOWN_SIGNAL      QUIT
+-#define NGX_TERMINATE_SIGNAL     TERM
++#define NGX_SHUTDOWN_SIGNAL      TERM
++#define NGX_TERMINATE_SIGNAL     QUIT
+ #define NGX_NOACCEPT_SIGNAL      WINCH
+ #define NGX_RECONFIGURE_SIGNAL   HUP


### PR DESCRIPTION
After compiling nginx with the modifications:

```shell
make build-heroku-18
```

I tested that the changes actually worked:

```shell
apt-get update
apt-get install -y python3-venv
python3 -m venv venv
./venv/bin/pip install gunicorn
FORCE=1 bin/start-nginx
./venv/bin/gunicorn -b unix:/tmp/nginx.socket app:app

# in another terminal (should hang for 15s assuming app is setup correctly)
curl localhost:5000

# in another terminal
# get the PID
ps aux | grep master

# should be graceful, that is nginx should shutdown after it finishes serving the request
kill -TERM $PID

FORCE=1 bin/start-nginx
# should kill nginx without waiting
# curl returns an error:
#   curl: (52) Empty reply from server
kill -QUIT $PID
```

The `app` used by `gunicorn` was the hello world with a sleep thrown in
so we mimic a long running request.

```python
import time

def app(environ, start_response):
        time.sleep(15)
        data = b"Hello, World!\n"
        start_response("200 OK", [
            ("Content-Type", "text/plain"),
            ("Content-Length", str(len(data)))
        ])
        return iter([data])
```

Based on https://github.com/heroku/heroku-buildpack-nginx/pull/56
https://admithubteam.atlassian.net/browse/AH-4919