### PR TITLE
remove references to cedar-14

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,4 @@
-build: build-cedar-14 build-heroku-16 build-heroku-18 build-heroku-20
-
-build-cedar-14:
-	@echo "Building nginx in Docker for cedar-14..."
-	@docker run -v $(shell pwd):/buildpack --rm -it -e "STACK=cedar-14" -e "NGINX_VERSION=1.9.5" -e "PCRE_VERSION=8.37" -e "HEADERS_MORE_VERSION=0.261" -w /buildpack heroku/cedar:14 scripts/build_nginx /buildpack/nginx-cedar-14.tgz
+build: build-heroku-16 build-heroku-18 build-heroku-20
 
 build-heroku-16:
 	@echo "Building nginx in Docker for heroku-16..."

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [x.x.x] - xxxx-xx-xx
+### Changes
+- [cedar-14] Removed
+
 ## [1.5.1] - 2020-08-22
 ### Changes
 - [readme.md] Updated custom build instructions

--- a/readme.md
+++ b/readme.md
@@ -4,12 +4,10 @@ Nginx-buildpack vendors NGINX inside a dyno and connects NGINX to an app server 
 
 ## Motivation
 
-Some application servers (e.g. Ruby's Unicorn) halt progress when dealing with network I/O. Heroku's Cedar routing stack [buffers only the headers](https://devcenter.heroku.com/articles/http-routing#request-buffering) of inbound requests. (The Cedar router will buffer the headers and body of a response up to 1MB) Thus, the Heroku router engages the dyno during the entire body transfer –from the client to dyno. For applications servers with blocking I/O, the latency per request will be degraded by the content transfer. By using NGINX in front of the application server, we can eliminate a great deal of transfer time from the application server. In addition to making request body transfers more efficient, all other I/O should be improved since the application server need only communicate with a UNIX socket on localhost. Basically, for webservers that are not designed for efficient, non-blocking I/O, we will benefit from having NGINX to handle all I/O operations.
+Some application servers (e.g. Ruby's Unicorn) halt progress when dealing with network I/O. Heroku's routing stack [buffers only the headers](https://devcenter.heroku.com/articles/http-routing#request-buffering) of inbound requests. (The router will buffer the headers and body of a response up to 1MB) Thus, the Heroku router engages the dyno during the entire body transfer –from the client to dyno. For applications servers with blocking I/O, the latency per request will be degraded by the content transfer. By using NGINX in front of the application server, we can eliminate a great deal of transfer time from the application server. In addition to making request body transfers more efficient, all other I/O should be improved since the application server need only communicate with a UNIX socket on localhost. Basically, for webservers that are not designed for efficient, non-blocking I/O, we will benefit from having NGINX to handle all I/O operations.
 
 ## Versions
 
-### Cedar-14 (deprecated)
-* NGINX Version: 1.9.5
 ### Heroku 16
 * NGINX Version: 1.9.5
 ### Heroku 18


### PR DESCRIPTION
Removing references to cedar-14 as it has been deprecated and we don't allow any new builds.