### PR TITLE
Add optional force https in sample config

### DIFF
--- a/config/nginx-solo-sample.conf.erb
+++ b/config/nginx-solo-sample.conf.erb
@@ -34,6 +34,11 @@ http {
 		keepalive_timeout 5;
 		client_max_body_size <%= ENV['NGINX_CLIENT_MAX_BODY_SIZE'] || 1 %>M;
 
+		// Uncomment this if you like to force all requests to https
+        	// if ($http_x_forwarded_proto != "https") {
+	        //   return 301 https://$host$request_uri;
+        	// }
+
 		root /app/public; # path to your app
 	}
 }


### PR DESCRIPTION
This just adds an optional force https mode in the sample nginx standalone config.