### PR TITLE
feat: nginx config root and config file path

### DIFF
--- a/bin/eval-config
+++ b/bin/eval-config
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+CONFIG_ROOT="${NGINX_CONFIG_ROOT:=config}"
+CONFIG_FILE="${NGINX_CONFIG_FILE:=nginx.conf.erb}"
+
+# Evaluate config to get $PORT
+erb $CONFIG_ROOT/$CONFIG_FILE > config/nginx.conf

--- a/bin/start-nginx
+++ b/bin/start-nginx
@@ -4,8 +4,7 @@ psmgr=/tmp/nginx-buildpack-wait
 rm -f $psmgr
 mkfifo $psmgr
 
-# Evaluate config to get $PORT
-erb config/nginx.conf.erb > config/nginx.conf
+./eval-config
 
 n=1
 while getopts :f option ${@:1:2}

--- a/bin/start-nginx-debug
+++ b/bin/start-nginx-debug
@@ -4,8 +4,7 @@ psmgr=/tmp/nginx-buildpack-wait
 rm -f $psmgr
 mkfifo $psmgr
 
-# Evaluate config to get $PORT
-erb config/nginx.conf.erb > config/nginx.conf
+./eval-config
 
 n=1
 while getopts :f option ${@:1:2}

--- a/bin/start-nginx-solo
+++ b/bin/start-nginx-solo
@@ -4,8 +4,7 @@ psmgr=/tmp/nginx-buildpack-wait
 rm -f $psmgr
 mkfifo $psmgr
 
-# Evaluate config to get $PORT
-erb config/nginx.conf.erb > config/nginx.conf
+./eval-config
 
 n=1
 while getopts :f option ${@:1:2}


### PR DESCRIPTION
Specifying a different root path for configs, as well as different paths for configs, helps a lot in setting up a universal build, especially with multiple buildpacks
If we do not specify anything in the envs, the default values will be chosen, but we can overwrite them and get more varied options for using