### PR TITLE
Update README's NGINX version

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,11 +9,11 @@ Some application servers (e.g. Ruby's Unicorn) halt progress when dealing with n
 ## Versions
 
 ### Heroku 18
-* NGINX Version: 1.20.1
+* NGINX Version: 1.20.2
 ### Heroku 20
-* NGINX Version: 1.20.1
+* NGINX Version: 1.20.2
 ### Heroku 22
-* NGINX Version: 1.20.1
+* NGINX Version: 1.20.2
 
 ## Requirements (Proxy Mode)
 


### PR DESCRIPTION
This was bumped early in 2022, but the README wasn't updated to reflect the correct nginx version. Now it is.