### PR TITLE
Document migrating from heroku-community/static buildpack

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [unlreleased] - XXXX-XX-XX
 ### Changes
 - [heroku-18] Removed
+- Add documentation for migrating from heroku-community/static buildpack
 
 ## [1.10] - 2023-06-13
 ### Changes

--- a/static.md
+++ b/static.md
@@ -23,6 +23,10 @@ web: bin/start-nginx-static
 1. Copy the [static config](config/nginx-static.conf.erb) into your app as `config/nginx.conf.erb`.
 2. Set the [document root](#document-root) for your app (default is `/app/dist`, this varies by framework/build system).
 
+#### Migrating from heroku-buildpack-static
+
+To extract the Nginx config from a prior `static.json` app, see [heroku-buildpack-static transition guide](https://github.com/heroku/heroku-buildpack-static#warning-heroku-buildpack-static-is-deprecated).
+
 ## Configuration
 
 Everything is set-up in `config/nginx.conf.erb`.


### PR DESCRIPTION
Update the Nginx "static mode" docs to link the transition guide in the deprecated Static buildpack.