### PR TITLE
Add http2 module

### DIFF
--- a/scripts/build_nginx
+++ b/scripts/build_nginx
@@ -36,6 +36,7 @@ configure_opts=(
   --with-http_gzip_static_module
   --with-http_realip_module
   --with-http_ssl_module
+  --with-http_v2_module
   --add-module="${temp_dir}/nginx-${NGINX_VERSION}/headers-more-nginx-module-${HEADERS_MORE_VERSION}"
   --add-module="${temp_dir}/nginx-${NGINX_VERSION}/nginx-uuid4-module-${UUID4_VERSION}"
 )


### PR DESCRIPTION
I am not sure if using `http2 on;` is needed if you already have _HTTP 2_ active in your runtime in Heroku. If that is the case,  feel free to disregard this PR.