### PR TITLE
Start script should crash on errors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [unreleased] - YYYY-MM-DD
+### Changes
+- `start-nginx-static` now crashes when misconfigured
 
 ## [1.14] - 2025-06-30
 ### Changes

--- a/bin/start-nginx-static
+++ b/bin/start-nginx-static
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 echo 'buildpack=nginx at=erb-interpolate-config'
 erb config/nginx.conf.erb > config/nginx.conf
 


### PR DESCRIPTION
 A [new app was misbehaving](https://salesforce-internal.slack.com/archives/C088M6TJL0K/p1752691933135909), and we realized that this `bin/start-nginx-static` script should crash on errors.