### PR TITLE
remove outdated note about logs not going to STDOUT

### DIFF
--- a/PROXY.md
+++ b/PROXY.md
@@ -21,8 +21,6 @@ The [default config `config/nginx.conf.erb`](config/nginx.conf.erb) will be load
 
 ## Logging
 
-**Proxy mode writes logs to files, which is not the Heroku way. They should go to stdout.**
-
 Nginx will output the following style of logs:
 
 ```


### PR DESCRIPTION
I'm guessing this note was made before the log redirection was implemented?

https://github.com/heroku/heroku-buildpack-nginx/blob/230c690591f6f9bc77d8e2c48cd9c40a65f02717/bin/start-nginx#L24-L29

